### PR TITLE
Don't quit, close.

### DIFF
--- a/ack.go
+++ b/ack.go
@@ -60,6 +60,7 @@ func (asn *ASN) AckerRx(pdu *PDU) (err error) {
 	if _, err = (NBOReader{pdu}).ReadNBO(&asn.Time.In); err != nil {
 		return
 	}
+	asn.Trace("rx", AckReqId, req)
 	asn.Acker.mutex.Lock()
 	f := asn.Acker.fmap[req]
 	asn.Acker.mutex.Unlock()
@@ -99,7 +100,7 @@ func (asn *ASN) Ack(req Requester, argv ...interface{}) {
 	(NBOWriter{ack}).WriteNBO(asn.Time.Out)
 	if err != nil {
 		asn.Trace("tx", AckReqId, req, err)
-		asn.Diag("nack", err)
+		Diag.Output(2, asn.Name.Session+" nack"+err.Error())
 		ErrFromError(err).Version(v).WriteTo(ack)
 		if len(argv) > 0 {
 			AckOut(ack, argv...)
@@ -108,9 +109,9 @@ func (asn *ASN) Ack(req Requester, argv ...interface{}) {
 		}
 	} else {
 		asn.Trace("tx", AckReqId, req, Success)
+		Diag.Output(2, asn.Name.Session+" ack")
 		Success.Version(v).WriteTo(ack)
 		AckOut(ack, argv...)
-		asn.Diag("ack")
 	}
 	asn.Tx(ack)
 }

--- a/cli.go
+++ b/cli.go
@@ -10,13 +10,14 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	"github.com/tgrennan/go-gnureadline"
 )
 
-func (adm *Adm) CLI() error {
-	var prompt string
+func (adm *Adm) CLI() (err error) {
+	var prompt, line string
 	home := os.Getenv("HOME")
 	term := os.Getenv("TERM")
 	history := filepath.Join(home, ".asnadm_history")
@@ -26,39 +27,39 @@ func (adm *Adm) CLI() error {
 	} else {
 		prompt = adm.asn.Name.Session + ": "
 	}
-	if _, err := os.Stat(history); err == nil {
-		gnureadline.ReadHistory(history)
+	if _, err = os.Stat(rc); err == nil {
+		if err = gnureadline.ReadInitFile(rc); err != nil {
+			return err
+		}
 	}
-	if _, err := os.Stat(rc); err == nil {
-		gnureadline.ReadInitFile(rc)
+	if _, err = os.Stat(history); err == nil {
+		gnureadline.ReadHistory(history)
+	} else {
+		err = nil
 	}
 	gnureadline.StifleHistory(16)
 	winch := make(chan os.Signal, 1)
-	winchStop := make(chan bool, 1)
+	done := make(Done, 1)
 	signal.Notify(winch, syscall.SIGWINCH)
-	defer signal.Stop(winch)
 	go func() {
 		for {
-			select {
-			case <-winch:
+			switch <-winch {
+			case syscall.SIGWINCH:
 				gnureadline.Rl_resize_terminal()
-			case <-winchStop:
-				return
+			case syscall.SIGTERM:
+				signal.Stop(winch)
+				gnureadline.Rl_reset_terminal(term)
+				done <- nil
+				runtime.Goexit()
 			}
 		}
 	}()
-	defer func() {
-		winchStop <- true
-		gnureadline.Rl_reset_terminal(term)
-	}()
-	for {
-		line, err := gnureadline.Readline(prompt, true)
-		if err != nil {
-			return err
-		}
-		err = adm.cmdLine(line)
-		if err != nil {
-			return err
+	for err == nil {
+		if line, err = gnureadline.Readline(prompt, true); err == nil {
+			err = adm.cmdLine(line)
 		}
 	}
+	winch <- syscall.SIGTERM
+	<-done
+	return
 }

--- a/err.go
+++ b/err.go
@@ -43,7 +43,6 @@ const (
 var (
 	// These aren't Nack'd Err codes
 	ErrDisestablished = errors.New("Disestablished session")
-	ErrSuspended      = errors.New("Suspended session")
 	ErrParse          = errors.New("Internal parse error")
 	ErrQuery          = errors.New("invalid or missing query string")
 

--- a/exec.go
+++ b/exec.go
@@ -143,8 +143,8 @@ func (ses *Ses) RxExec(pdu *PDU) error {
 	} else {
 		args = strings.Split(string(cmd[:n]), "\x00")
 	}
-	ses.ASN.Diagf("exec pdu %p: %v\n", pdu, args)
 	pdu.Clone()
+	ses.ASN.Diag("exec", args)
 	ses.ExecMutex.Lock()
 	go ses.GoExec(req, pdu, args...)
 	return nil
@@ -158,6 +158,7 @@ func (ses *Ses) GoExec(req Requester, pdu *PDU, args ...string) {
 
 func (ses *Ses) Exec(req Requester, r io.Reader,
 	args ...string) interface{} {
+	ses.ASN.Trace("rx", ExecReqId, req, args)
 	switch args[0] {
 	case "exec-help", "help":
 		return UsageCommands

--- a/logger.go
+++ b/logger.go
@@ -25,7 +25,7 @@ func (l *Logger) ASN(asn *ASN, v ...interface{}) {
 }
 
 func (l *Logger) ASNf(asn *ASN, format string, v ...interface{}) {
-	Diag.Output(3, asn.Name.Session+" "+fmt.Sprintf(format, v...))
+	l.Output(3, asn.Name.Session+" "+fmt.Sprintf(format, v...))
 }
 
 func (l *Logger) Close() (err error) {
@@ -84,7 +84,7 @@ func (l *Logger) Priority() syslog.Priority {
 }
 
 func (l *Logger) Write(b []byte) (int, error) {
-	l.Output(2, string(b))
+	l.Output(3, string(b))
 	return len(b), nil
 }
 

--- a/main.go
+++ b/main.go
@@ -240,7 +240,9 @@ func main() {
 	} else {
 		go cmd.Server(FS.Args()...)
 	}
-	err = cmd.Wait()
+	if err = cmd.Wait(); err == io.EOF {
+		err = nil
+	}
 	FlushASN()
 	FlushPDU()
 	Log.Close()

--- a/pdu.go
+++ b/pdu.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -55,7 +54,7 @@ func newPDU() (pdu *PDU) {
 		pdu = new(PDU)
 	}
 	pdu.ref = 1
-	Diag.Output(3, fmt.Sprintf("new pdu %p\n", pdu))
+	// Diag.Output(3, fmt.Sprintf("new pdu %p\n", pdu))
 	return
 }
 
@@ -147,7 +146,7 @@ func (pdu *PDU) Free() {
 	if pdu.deref() > 0 {
 		return
 	}
-	Diag.Output(2, fmt.Sprintf("free pdu %p\n", pdu))
+	// Diag.Output(2, fmt.Sprintf("free pdu %p\n", pdu))
 	if pdu.File != nil {
 		pdu.File.Close()
 		pdu.File = nil


### PR DESCRIPTION
Instead of ending sessions with a quit/ack exchange, a client simply closes its
connection as outlined.

```
Client              Server
Admin:close(TxQ)
(*ASN).GoTx:close(conn)
(*ASN).GoTx:Goexit()        (*ASN).GoRx:close(RxQ)
(*ASN).GoRx:close(RxQ)      (*ASN).GoRx:Goexit()
(*ASN).GoRx:Goexit()        (*srv).handler:close(TxQ)
(*adm).handler:Goexit()     (*srv).handler:close(TxQ)
                (*ASN).GoTx:Goexit()
```

Signed-off-by: Tom Grennan tom@apptimist.co
